### PR TITLE
fix: load Tailwind via CDN script

### DIFF
--- a/Report.md
+++ b/Report.md
@@ -1,54 +1,23 @@
 # Report
 
 ## Summary
-- Fixed broken Tailwind CSS link so page styling loads correctly.
-- Enabled automatic upload preview by submitting the form as soon as files are chosen or dropped, removing the manual submit button.
+- **Requirement**: eMAG upload page lacked styling.
+- **Implementation**: Replaced invalid Tailwind CSS stylesheet link with the official CDN script so styles load correctly.
 
 ## Code Snippets
 ### emag.php
 **Before**
 ```html
-<link href="https://cdn.jsdelivr.net/npm/tailwindcss@^3/dist/tailwind.min.css" rel="stylesheet"/>
-...
-<button type="submit" class="px-6 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors">Incarca</button>
-dropZone.addEventListener('click', () => fileInput.click());
-...
-dropZone.addEventListener('drop', e => {
-  e.preventDefault();
-  dropZone.classList.remove('bg-blue-50','dark:bg-gray-700');
-  const files = e.dataTransfer.files;
-  if (files.length > 10) { alert('Maxim 10 fisiere'); return; }
-  const dt = new DataTransfer();
-  for (let i = 0; i < files.length && i < 10; i++) {
-    dt.items.add(files[i]);
-  }
-  fileInput.files = dt.files;
-});
+<link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css" rel="stylesheet"/>
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 ```
 
 **After**
 ```html
-<link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css" rel="stylesheet"/>
-...
-fileInput.addEventListener('change', () => {
-  if (fileInput.files.length > 0) {
-    fileInput.form.submit();
-  }
-});
-dropZone.addEventListener('click', () => fileInput.click());
-...
-dropZone.addEventListener('drop', e => {
-  e.preventDefault();
-  dropZone.classList.remove('bg-blue-50','dark:bg-gray-700');
-  const files = e.dataTransfer.files;
-  if (files.length > 10) { alert('Maxim 10 fisiere'); return; }
-  const dt = new DataTransfer();
-  for (let i = 0; i < files.length && i < 10; i++) {
-    dt.items.add(files[i]);
-  }
-  fileInput.files = dt.files;
-  if (fileInput.files.length > 0) {
-    fileInput.form.submit();
-  }
-});
+<script src="https://cdn.tailwindcss.com"></script>
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 ```
+
+## Testing
+- `php -l emag.php`
+- `php -l emag/SimpleXLSX.php`

--- a/emag.php
+++ b/emag.php
@@ -98,7 +98,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_FILES['files'])) {
 <meta charset="utf-8"/>
 <title>eMAG Upload</title>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.1/dist/tailwind.min.css" rel="stylesheet"/>
+<script src="https://cdn.tailwindcss.com"></script>
 <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
 </head>
 <body class="font-sans bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100 min-h-screen transition-colors">


### PR DESCRIPTION
## Summary
- load Tailwind via official CDN script so emag upload page has styling
- document fix in Report.md

## Testing
- `php -l emag.php`
- `php -l emag/SimpleXLSX.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6064bb44c833386c08c521ed05a1c