### PR TITLE
Add standalone 3D alien shooter demo

### DIFF
--- a/demo04_RNDa7b9c2.html
+++ b/demo04_RNDa7b9c2.html
@@ -1,0 +1,715 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Alien Horizon - 3D Shooter Demo</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      font-family: 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      overflow: hidden;
+      background: radial-gradient(circle at top, #1e2a5c 0%, #050608 60%, #000 100%);
+      color: #f5f7ff;
+    }
+
+    canvas {
+      display: block;
+    }
+
+    #overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      gap: 1.5rem;
+      background: rgba(3, 6, 15, 0.92);
+      backdrop-filter: blur(6px);
+      text-align: center;
+      padding: 3rem 1.5rem;
+      transition: opacity 0.4s ease;
+      z-index: 5;
+    }
+
+    #overlay.hidden {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    #overlay button {
+      background: linear-gradient(135deg, #38d9ff, #9d4dff);
+      color: #fff;
+      border: none;
+      padding: 0.9rem 2.7rem;
+      border-radius: 999px;
+      font-size: 1.1rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      cursor: pointer;
+      box-shadow: 0 15px 45px rgba(56, 217, 255, 0.35);
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    #overlay button:hover {
+      transform: translateY(-3px);
+      box-shadow: 0 20px 60px rgba(157, 77, 255, 0.45);
+    }
+
+    #hud {
+      position: fixed;
+      top: 1rem;
+      left: 50%;
+      transform: translateX(-50%);
+      min-width: 280px;
+      background: rgba(12, 18, 36, 0.7);
+      backdrop-filter: blur(4px);
+      padding: 1rem 1.5rem;
+      border-radius: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+      align-items: center;
+      z-index: 4;
+      border: 1px solid rgba(90, 147, 255, 0.25);
+      text-shadow: 0 0 10px rgba(90, 147, 255, 0.4);
+    }
+
+    #hud h1 {
+      margin: 0;
+      font-size: 1.2rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    #stats {
+      font-size: 0.95rem;
+      display: flex;
+      gap: 1.5rem;
+      text-transform: uppercase;
+    }
+
+    #slider-wrapper {
+      width: 100%;
+      display: grid;
+      gap: 0.3rem;
+    }
+
+    input[type="range"] {
+      width: 100%;
+      accent-color: #69d8ff;
+    }
+
+    #instructions {
+      max-width: 550px;
+      line-height: 1.6;
+      font-size: 1.05rem;
+      color: #c8d8ff;
+    }
+
+    #crosshair {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      width: 22px;
+      height: 22px;
+      transform: translate(-50%, -50%);
+      pointer-events: none;
+      z-index: 3;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    #crosshair::before,
+    #crosshair::after {
+      content: '';
+      position: absolute;
+      background: #8cf4ff;
+      box-shadow: 0 0 14px rgba(140, 244, 255, 0.8);
+    }
+
+    #crosshair::before {
+      top: 50%;
+      left: 0;
+      right: 0;
+      height: 2px;
+      transform: translateY(-50%);
+    }
+
+    #crosshair::after {
+      left: 50%;
+      top: 0;
+      bottom: 0;
+      width: 2px;
+      transform: translateX(-50%);
+    }
+
+    #status-banner {
+      position: fixed;
+      bottom: 1rem;
+      left: 50%;
+      transform: translateX(-50%);
+      padding: 0.75rem 1.5rem;
+      background: rgba(2, 8, 18, 0.8);
+      border-radius: 999px;
+      border: 1px solid rgba(79, 201, 255, 0.4);
+      font-size: 0.95rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+      z-index: 4;
+    }
+
+    @media (max-width: 700px) {
+      #hud {
+        left: 1rem;
+        right: 1rem;
+        transform: none;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div id="overlay">
+    <h1>Alien Horizon</h1>
+    <p id="instructions">
+      You are stationed on a lonely asteroid base. Hostile aliens warp in from every direction.
+      Lock the pointer to enter the cockpit, move with <strong>WASD</strong>, dodge with <strong>Space</strong>,
+      and click to fire plasma bolts. Adjust the <strong>polygon density</strong> slider at any time to tailor
+      performance or fidelity.
+    </p>
+    <div id="slider-wrapper">
+      <label for="polygon-slider">Polygon density: <span id="polygon-count">12</span> segments</label>
+      <input type="range" id="polygon-slider" min="4" max="32" step="1" value="12" />
+    </div>
+    <button id="start-button">Engage</button>
+  </div>
+
+  <div id="hud" hidden>
+    <h1>Alien Horizon</h1>
+    <div id="stats">
+      <span>Score: <strong id="score">0</strong></span>
+      <span>Streak: <strong id="streak">0</strong></span>
+      <span>Wave: <strong id="wave">1</strong></span>
+    </div>
+    <div id="slider-wrapper">
+      <label for="polygon-slider-live">Polygon density: <span id="polygon-count-live">12</span></label>
+      <input type="range" id="polygon-slider-live" min="4" max="32" step="1" value="12" />
+    </div>
+  </div>
+
+  <div id="crosshair"></div>
+  <div id="status-banner"></div>
+
+  <script type="module">
+    import * as THREE from 'https://cdn.jsdelivr.net/npm/three@0.161.0/build/three.module.js';
+    import { PointerLockControls } from 'https://cdn.jsdelivr.net/npm/three@0.161.0/examples/jsm/controls/PointerLockControls.js';
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(window.devicePixelRatio);
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.shadowMap.enabled = true;
+    renderer.outputEncoding = THREE.sRGBEncoding;
+    document.body.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.FogExp2(0x040712, 0.015);
+
+    const camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.1, 2000);
+    camera.position.set(0, 1.7, 6);
+
+    const controls = new PointerLockControls(camera, document.body);
+    const velocity = new THREE.Vector3();
+    const direction = new THREE.Vector3();
+    const upVector = new THREE.Vector3(0, 1, 0);
+    let moveForward = false;
+    let moveBackward = false;
+    let moveLeft = false;
+    let moveRight = false;
+    let canJump = false;
+
+    const ambientLight = new THREE.AmbientLight(0x4b73ff, 0.3);
+    scene.add(ambientLight);
+
+    const mainLight = new THREE.DirectionalLight(0x99c0ff, 1.1);
+    mainLight.position.set(12, 24, -8);
+    mainLight.castShadow = true;
+    mainLight.shadow.mapSize.set(2048, 2048);
+    mainLight.shadow.camera.near = 0.5;
+    mainLight.shadow.camera.far = 200;
+    scene.add(mainLight);
+
+    const planet = new THREE.Mesh(
+      new THREE.SphereGeometry(60, 48, 32),
+      new THREE.MeshPhongMaterial({
+        color: 0x13294b,
+        emissive: 0x0b1330,
+        shininess: 12,
+        wireframe: false,
+      })
+    );
+    planet.position.set(0, -62, 0);
+    planet.receiveShadow = true;
+    scene.add(planet);
+
+    const baseGeometry = new THREE.CylinderGeometry(22, 30, 4, 24, 2, true);
+    const baseMaterial = new THREE.MeshStandardMaterial({
+      color: 0x1c1f35,
+      emissive: 0x040a1a,
+      metalness: 0.4,
+      roughness: 0.6,
+      side: THREE.DoubleSide,
+    });
+    const base = new THREE.Mesh(baseGeometry, baseMaterial);
+    base.position.set(0, -2, 0);
+    base.receiveShadow = true;
+    scene.add(base);
+
+    const holoMaterial = new THREE.MeshPhongMaterial({
+      color: 0x2b86ff,
+      emissive: 0x1c2fff,
+      transparent: true,
+      opacity: 0.25,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+    });
+
+    const ring = new THREE.Mesh(new THREE.TorusGeometry(35, 0.6, 12, 64), holoMaterial);
+    ring.rotation.x = Math.PI / 2;
+    ring.receiveShadow = true;
+    scene.add(ring);
+
+    const starParticles = (() => {
+      const starGeo = new THREE.BufferGeometry();
+      const starCount = 800;
+      const positions = new Float32Array(starCount * 3);
+      for (let i = 0; i < starCount; i++) {
+        const angle = Math.random() * Math.PI * 2;
+        const radius = 260 + Math.random() * 400;
+        const height = (Math.random() - 0.5) * 300;
+        positions[i * 3] = Math.cos(angle) * radius;
+        positions[i * 3 + 1] = height;
+        positions[i * 3 + 2] = Math.sin(angle) * radius;
+      }
+      starGeo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      const starMaterial = new THREE.PointsMaterial({
+        color: 0x98fffe,
+        size: 1.2,
+        transparent: true,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false,
+      });
+      return new THREE.Points(starGeo, starMaterial);
+    })();
+    scene.add(starParticles);
+
+    const bullets = [];
+    const aliens = [];
+    const explosions = [];
+
+    let score = 0;
+    let streak = 0;
+    let wave = 1;
+    let polygonSegments = 12;
+    let lastShotTime = 0;
+    let lastSpawnTime = 0;
+    let spawnInterval = 2600;
+    let isRunning = false;
+
+    const scoreEl = document.getElementById('score');
+    const streakEl = document.getElementById('streak');
+    const waveEl = document.getElementById('wave');
+    const crosshair = document.getElementById('crosshair');
+    const statusBanner = document.getElementById('status-banner');
+    const hud = document.getElementById('hud');
+
+    const audioContext = new (window.AudioContext || window.webkitAudioContext)();
+
+    function playTone({ frequency = 880, duration = 0.12, type = 'sine', gain = 0.3 }) {
+      const now = audioContext.currentTime;
+      const oscillator = audioContext.createOscillator();
+      const gainNode = audioContext.createGain();
+      oscillator.type = type;
+      oscillator.frequency.setValueAtTime(frequency, now);
+      gainNode.gain.setValueAtTime(gain, now);
+      gainNode.gain.exponentialRampToValueAtTime(0.001, now + duration);
+      oscillator.connect(gainNode).connect(audioContext.destination);
+      oscillator.start(now);
+      oscillator.stop(now + duration);
+    }
+
+    function showBanner(message) {
+      statusBanner.textContent = message;
+      statusBanner.style.opacity = 1;
+      setTimeout(() => (statusBanner.style.opacity = 0), 1800);
+    }
+
+    function createAlien() {
+      const radius = 1.1 + Math.random() * 0.8;
+      const geometry = new THREE.SphereGeometry(radius, polygonSegments, Math.max(4, Math.round(polygonSegments / 2)));
+      const material = new THREE.MeshStandardMaterial({
+        color: new THREE.Color(`hsl(${180 + Math.random() * 120}, 80%, 55%)`),
+        emissive: new THREE.Color(`hsl(${180 + Math.random() * 120}, 70%, 25%)`),
+        roughness: 0.25,
+        metalness: 0.6,
+        flatShading: polygonSegments <= 10,
+      });
+      const alien = new THREE.Mesh(geometry, material);
+      const distance = 36 + Math.random() * 40;
+      const angle = Math.random() * Math.PI * 2;
+      alien.position.set(Math.cos(angle) * distance, 4 + Math.random() * 6, Math.sin(angle) * distance);
+      alien.castShadow = true;
+      alien.userData = {
+        hitpoints: 1 + Math.floor(wave / 2),
+        speed: 0.008 + Math.random() * 0.01 + wave * 0.0015,
+        sway: Math.random() * 0.8,
+        offset: Math.random() * Math.PI * 2,
+      };
+      scene.add(alien);
+      aliens.push(alien);
+    }
+
+    function refreshAlienDetail() {
+      aliens.forEach((alien, index) => {
+        const radius = alien.geometry.parameters.radius;
+        alien.geometry.dispose();
+        const newGeometry = new THREE.SphereGeometry(
+          radius,
+          polygonSegments,
+          Math.max(4, Math.round(polygonSegments / 2))
+        );
+        alien.geometry = newGeometry;
+        alien.material.flatShading = polygonSegments <= 10;
+        alien.material.needsUpdate = true;
+        alien.userData.offset += index * 0.1;
+      });
+    }
+
+    function createBullet() {
+      const now = performance.now();
+      if (now - lastShotTime < 220) return;
+      lastShotTime = now;
+
+      playTone({ frequency: 940, duration: 0.1, type: 'sawtooth', gain: 0.25 });
+
+      const geometry = new THREE.CapsuleGeometry(0.06, 0.4, 4, 8);
+      const material = new THREE.MeshBasicMaterial({
+        color: 0x6ff6ff,
+        transparent: true,
+        opacity: 0.8,
+        blending: THREE.AdditiveBlending,
+      });
+      const bullet = new THREE.Mesh(geometry, material);
+      bullet.castShadow = false;
+      const start = controls.getObject().position.clone();
+      start.y += 0.2;
+      bullet.position.copy(start);
+      const dir = new THREE.Vector3();
+      controls.getDirection(dir);
+      bullet.userData = {
+        velocity: dir.multiplyScalar(0.9),
+        life: 2000,
+        spawnTime: now,
+      };
+      scene.add(bullet);
+      bullets.push(bullet);
+    }
+
+    function createExplosion(position) {
+      const geometry = new THREE.SphereGeometry(0.1, 6, 4);
+      const material = new THREE.MeshBasicMaterial({
+        color: 0xfff799,
+        transparent: true,
+        opacity: 0.9,
+        blending: THREE.AdditiveBlending,
+      });
+      const explosion = new THREE.Mesh(geometry, material);
+      explosion.position.copy(position);
+      explosion.userData = { start: performance.now(), duration: 420 };
+      scene.add(explosion);
+      explosions.push(explosion);
+
+      playTone({ frequency: 180 + Math.random() * 80, duration: 0.22, type: 'triangle', gain: 0.5 });
+    }
+
+    function handleKeyDown(event) {
+      switch (event.code) {
+        case 'ArrowUp':
+        case 'KeyW':
+          moveForward = true;
+          break;
+        case 'ArrowLeft':
+        case 'KeyA':
+          moveLeft = true;
+          break;
+        case 'ArrowDown':
+        case 'KeyS':
+          moveBackward = true;
+          break;
+        case 'ArrowRight':
+        case 'KeyD':
+          moveRight = true;
+          break;
+        case 'Space':
+          if (canJump === true) {
+            velocity.y += 6;
+            canJump = false;
+            playTone({ frequency: 620, duration: 0.18, type: 'square', gain: 0.2 });
+          }
+          break;
+      }
+    }
+
+    function handleKeyUp(event) {
+      switch (event.code) {
+        case 'ArrowUp':
+        case 'KeyW':
+          moveForward = false;
+          break;
+        case 'ArrowLeft':
+        case 'KeyA':
+          moveLeft = false;
+          break;
+        case 'ArrowDown':
+        case 'KeyS':
+          moveBackward = false;
+          break;
+        case 'ArrowRight':
+        case 'KeyD':
+          moveRight = false;
+          break;
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    document.addEventListener('keyup', handleKeyUp);
+
+    document.addEventListener('click', () => {
+      if (!isRunning) return;
+      if (!controls.isLocked) {
+        controls.lock();
+        return;
+      }
+      createBullet();
+    });
+
+    controls.addEventListener('lock', () => {
+      crosshair.style.opacity = 1;
+      hud.hidden = false;
+      overlay.classList.add('hidden');
+    });
+
+    controls.addEventListener('unlock', () => {
+      crosshair.style.opacity = 0;
+      hud.hidden = true;
+      overlay.classList.remove('hidden');
+      isRunning = false;
+    });
+
+    const overlay = document.getElementById('overlay');
+    const startButton = document.getElementById('start-button');
+    const polygonSlider = document.getElementById('polygon-slider');
+    const polygonSliderLive = document.getElementById('polygon-slider-live');
+    const polygonCountLabel = document.getElementById('polygon-count');
+    const polygonCountLiveLabel = document.getElementById('polygon-count-live');
+
+    function syncSliders(value) {
+      polygonSegments = Number(value);
+      polygonSlider.value = value;
+      polygonSliderLive.value = value;
+      polygonCountLabel.textContent = value;
+      polygonCountLiveLabel.textContent = value;
+      refreshAlienDetail();
+    }
+
+    polygonSlider.addEventListener('input', (event) => {
+      syncSliders(event.target.value);
+    });
+
+    polygonSliderLive.addEventListener('input', (event) => {
+      syncSliders(event.target.value);
+    });
+
+    startButton.addEventListener('click', () => {
+      if (audioContext.state === 'suspended') {
+        audioContext.resume();
+      }
+      overlay.classList.add('hidden');
+      showBanner('Welcome to Alien Horizon');
+      setTimeout(() => controls.lock(), 250);
+      startGame();
+    });
+
+    function startGame() {
+      if (isRunning) return;
+      isRunning = true;
+      score = 0;
+      streak = 0;
+      wave = 1;
+      spawnInterval = 2600;
+      lastSpawnTime = 0;
+      bullets.splice(0).forEach((b) => scene.remove(b));
+      aliens.splice(0).forEach((a) => scene.remove(a));
+      explosions.splice(0).forEach((e) => scene.remove(e));
+      scoreEl.textContent = score;
+      streakEl.textContent = streak;
+      waveEl.textContent = wave;
+    }
+
+    function updatePlayer(delta) {
+      velocity.x -= velocity.x * 10.0 * delta;
+      velocity.z -= velocity.z * 10.0 * delta;
+      velocity.y -= 18 * delta;
+
+      direction.z = Number(moveForward) - Number(moveBackward);
+      direction.x = Number(moveRight) - Number(moveLeft);
+      direction.normalize();
+
+      if (moveForward || moveBackward) velocity.z -= direction.z * 40.0 * delta;
+      if (moveLeft || moveRight) velocity.x -= direction.x * 40.0 * delta;
+
+      controls.moveRight(-velocity.x * delta);
+      controls.moveForward(-velocity.z * delta);
+
+      controls.getObject().position.y += velocity.y * delta;
+
+      if (controls.getObject().position.y < 1.7) {
+        velocity.y = 0;
+        controls.getObject().position.y = 1.7;
+        canJump = true;
+      }
+    }
+
+    function updateBullets(delta) {
+      const now = performance.now();
+      for (let i = bullets.length - 1; i >= 0; i--) {
+        const bullet = bullets[i];
+        bullet.position.addScaledVector(bullet.userData.velocity, delta * 60);
+        bullet.userData.life -= delta * 1000;
+        bullet.rotation.x += delta * 8;
+        if (bullet.userData.life <= 0) {
+          scene.remove(bullet);
+          bullets.splice(i, 1);
+        }
+      }
+    }
+
+    function updateAliens(delta) {
+      const playerPos = controls.getObject().position;
+      for (let i = aliens.length - 1; i >= 0; i--) {
+        const alien = aliens[i];
+        const userData = alien.userData;
+        const dir = playerPos.clone().sub(alien.position).normalize();
+        alien.position.addScaledVector(dir, userData.speed * delta * 60);
+        alien.position.y += Math.sin(performance.now() * 0.002 + userData.offset) * userData.sway * delta;
+        alien.lookAt(playerPos.x, alien.position.y, playerPos.z);
+
+        if (alien.position.distanceTo(playerPos) < 2.2) {
+          playTone({ frequency: 120, duration: 0.35, type: 'sawtooth', gain: 0.6 });
+          showBanner('Hull Breach! Resetting...');
+          controls.unlock();
+          startGame();
+          break;
+        }
+      }
+    }
+
+    function checkCollisions() {
+      for (let i = aliens.length - 1; i >= 0; i--) {
+        const alien = aliens[i];
+        const radius = alien.geometry.parameters.radius * 0.9;
+        for (let j = bullets.length - 1; j >= 0; j--) {
+          const bullet = bullets[j];
+          if (bullet.position.distanceTo(alien.position) <= radius) {
+            scene.remove(bullet);
+            bullets.splice(j, 1);
+            alien.userData.hitpoints -= 1;
+            if (alien.userData.hitpoints <= 0) {
+              createExplosion(alien.position.clone());
+              scene.remove(alien);
+              aliens.splice(i, 1);
+              score += 150;
+              streak += 1;
+              scoreEl.textContent = score;
+              streakEl.textContent = streak;
+              if (streak % 5 === 0) {
+                showBanner('Streak x' + streak + '!');
+              }
+              if (score !== 0 && score % 1200 === 0) {
+                wave += 1;
+                spawnInterval = Math.max(900, spawnInterval - 240);
+                waveEl.textContent = wave;
+                showBanner('Wave ' + wave + ' inbound!');
+              }
+            }
+            break;
+          }
+        }
+      }
+    }
+
+    function updateExplosions(delta) {
+      const now = performance.now();
+      for (let i = explosions.length - 1; i >= 0; i--) {
+        const explosion = explosions[i];
+        const age = now - explosion.userData.start;
+        const progress = age / explosion.userData.duration;
+        explosion.scale.setScalar(1 + progress * 6);
+        explosion.material.opacity = THREE.MathUtils.lerp(0.9, 0, progress);
+        if (progress >= 1) {
+          scene.remove(explosion);
+          explosions.splice(i, 1);
+        }
+      }
+    }
+
+    const clock = new THREE.Clock();
+
+    function animate() {
+      if (!isRunning) {
+        renderer.render(scene, camera);
+        return;
+      }
+      requestAnimationFrame(animate);
+      const delta = Math.min(0.05, clock.getDelta());
+      updatePlayer(delta);
+      updateBullets(delta);
+      updateAliens(delta);
+      updateExplosions(delta);
+      starParticles.rotation.y += delta * 0.02;
+
+      const now = performance.now();
+      if (now - lastSpawnTime > spawnInterval) {
+        const spawnCount = Math.min(4, 1 + Math.floor(wave / 2));
+        for (let i = 0; i < spawnCount; i++) {
+          createAlien();
+        }
+        lastSpawnTime = now;
+      }
+
+      checkCollisions();
+      renderer.render(scene, camera);
+    }
+
+    animate();
+
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    syncSliders(polygonSegments);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `demo04_RNDa7b9c2.html` containing a self-contained Three.js alien shooter demo
- implement adjustable polygon density slider with synchronized controls and HUD
- include pointer-lock gameplay, particle and sound effects, and score tracking overlays

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d6716aa9cc8333ad172b3521569254